### PR TITLE
Updated README to include missing setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ module.exports = function(config) {
     notifyReporter: {
       reportEachFailure: true, // Default: false, Will notify on every failed sepc
       reportSuccess: false, // Default: true, Will notify when a suite was successful
-    }
+    },
+    
+    // add karma-notify-reporter to plugins
+    plugins: [
+      'karma-notify-reporter'
+    ]
   });
 };
 ```


### PR DESCRIPTION
I couldn't figure out why I kept getting the following error when I followed the steps to install this plugin:

```
WARN [reporter]: Can not load "notify", it is not registered!
  Perhaps you are missing some plugin?
```

After some googling, I found I needed to add the plugin to the `plugins` array in `karma.conf.js`. This pull request adds that to the example Karma configuration code in the README.
