### PR TITLE
Adds a missing return keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var NotifyReporter = function(baseReporterDecorator, helper, logger, config, for
 
     if(reportSuccess) {
       msg = messages.success;
-      notifier.notify(helper.merge(msg, {'message': util.format(msg.message, results.success, time), 'title': util.format(msg.title, browser.name)}));
+      return notifier.notify(helper.merge(msg, {'message': util.format(msg.message, results.success, time), 'title': util.format(msg.title, browser.name)}));
     }
   };
 


### PR DESCRIPTION
Testing this plugin out, I could get a notification for failing tests, but not passing ones. After looking through the source a bit, I noticed a missing `return` keyword, which when added made the passing tests notification work.
