### PR TITLE
Consider bumping node-notifier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "notify-send"
   ],
   "dependencies": {
-    "node-notifier": "^4.5.0",
+    "node-notifier": "^5.1.2",
     "snyk": "^1.47.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Motivation for this PR is the recent https://github.com/chjj/marked/issues/997 "Potential Security Vulnerability" issue and the tons of Github notifications about it.

This is the chain of how is this affecting `karma-notify-reporter':

``` shell
> npm list marked

`-- karma-notify-reporter@1.0.1
  `-- node-notifier@4.6.1
    `-- cli-usage@0.1.4
      `-- marked@0.3.6
```

Thanks to the awesome @snyk-bot the vulnerability is fixed here https://github.com/jdcataldo/karma-notify-reporter/commit/bf04cb512186cdfa913e20ee1d727423c6d2b19b

However, updating the node notifier to [v5.1.2](https://github.com/mikaelbr/node-notifier/blob/v5.1.2/package.json), which is not using `cli-usage` at all, therefore `marked` as well.

``` shell
> npm list marked
`-- (empty)
```

[node-notifier changelog](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500) states:

> **v5.0.0**
> *Breaking Changes*
> Note/TL;DR: If you are just using node-notifier with things like message, title and icon, v5 should work just as before.


And here, we are not using `node-notifier` features more than the unchanged defaults.
a manual test of this will pass successfully-which is how `karma-notify-reporter` mostly uses `node-notifier`-:
**test.js**
``` js
var notifier = require('node-notifier'),
    path     = require('path');


var message = {
    displayName : 'Success',
    title       : 'PASSED - PhantomJs',
    message     : '56 tests passed in 3 sec.',
    icon        : path.join(__dirname, 'images/success.png')
};

notifier.notify(message);

```

Next step is to update and publish `karma-notify-reporter` itself.
