### PR TITLE
Update node-notifier dependency, fix broken variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ var NotifyReporter = function(baseReporterDecorator, helper, logger, config, for
       reportSuccess       = typeof reporterConfig.reportSuccess !== 'undefined' ? reporterConfig.reportSuccess : true,
       reportEachFailure   = typeof reporterConfig.reportEachFailure !== 'undefined' ? reporterConfig.reportEachFailure : true,
       reportBackToSuccess = typeof reporterConfig.reportBackToSuccess !==  'undefined' ? reporterConfig.reportBackToSuccess : false,
-      notifier            = new Notification(),
       msg;
 
   baseReporterDecorator(this);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "notify-send"
   ],
   "dependencies": {
-    "node-notifier": "^5.1.2",
+    "node-notifier": "^5.3.0",
     "snyk": "^1.47.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
There was a security vulnerability in the dependency chain of `node-notifier`, which is now resolved via updating the dependency to the latest version.

Also, there was a bit of a mismatch of variable names currently in `index.js` – `node-notifier` was imported as `notifier`, but then a new variable assigned to `notifier` (through `notifier = new Notifier()` causing an error. It seems `node-notifier` automatically (at least in 5.3.0) exports an instance of the correct notifier for the current OS (rather than a class), so I simply deleted the variable assignment and things seem to work OK. 