### PR TITLE
Move devDependencies under proper section

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "notify-send"
   ],
   "dependencies": {
-    "node-notifier": "^5.3.0",
+    "node-notifier": "^5.3.0"
+  },
+  "devDependencies": {
     "snyk": "^1.47.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
"snyk" package is used during development only but because it was listed under `dependencies` - it becomes installed in my project during each `npm install` and provides some internal conflicts in my case. Therefore, moved `snyk` package under proper section of `package.json` -> devDependencies